### PR TITLE
Add unit tests bigquery internal

### DIFF
--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryEnvironmentPropertiesTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryEnvironmentPropertiesTest.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PROJECT_ID;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static com.amazonaws.athena.connectors.google.bigquery.BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID;
+import static com.amazonaws.athena.connectors.google.bigquery.BigQueryConstants.GCP_PROJECT_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class BigQueryEnvironmentPropertiesTest {
+
+    private Map<String, String> connectionProperties;
+    private BigQueryEnvironmentProperties bigQueryEnvironmentProperties;
+    private static final String SECRET_NAME_VALUE = "bigQuery_Secret";
+
+    @Before
+    public void setup() {
+        connectionProperties = new HashMap<>();
+        connectionProperties.put(SECRET_NAME, SECRET_NAME_VALUE);
+        bigQueryEnvironmentProperties = new BigQueryEnvironmentProperties();
+    }
+
+    @Test
+    public void testConnectionPropertiesToEnvironment_When_ProjectId_NotPresent() {
+        Map<String, String> result = bigQueryEnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+        assertNull(result.get(GCP_PROJECT_ID));
+        assertEquals(SECRET_NAME_VALUE, result.get(ENV_BIG_QUERY_CREDS_SM_ID));
+    }
+
+    @Test
+    public void testConnectionPropertiesToEnvironment_When_ProjectId_Present() {
+        final String expectedValue = "testProject";
+        connectionProperties.put(PROJECT_ID, expectedValue);
+        Map<String, String> result = bigQueryEnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+        assertEquals(expectedValue, result.get(GCP_PROJECT_ID));
+        assertEquals(SECRET_NAME_VALUE, result.get(ENV_BIG_QUERY_CREDS_SM_ID));
+    }
+
+}

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryExceptionFilterTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryExceptionFilterTest.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery;
+
+import com.google.cloud.bigquery.BigQueryException;
+import org.junit.Test;
+import software.amazon.awssdk.services.athena.model.AthenaException;
+
+import static com.amazonaws.athena.connectors.google.bigquery.BigQueryExceptionFilter.EXCEPTION_FILTER;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BigQueryExceptionFilterTest {
+
+    @Test
+    public void testIsMatch_When_Rate_Exceeded()
+    {
+        boolean match = EXCEPTION_FILTER.isMatch(AthenaException.builder().message("Rate exceeded").build());
+        assertTrue(match);
+    }
+
+    @Test
+    public void testIsMatch_When_Exceeded_Rate_Limits()
+    {
+        boolean match = EXCEPTION_FILTER.isMatch(new BigQueryException(1, "Exceeded rate limits"));
+        assertTrue(match);
+    }
+
+    @Test
+    public void testIsMatch_When_Other_ErrorMessage()
+    {
+        boolean match = EXCEPTION_FILTER.isMatch(AthenaException.builder().message("other").build());
+        assertFalse(match);
+    }
+
+}

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParserTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParserTest.java
@@ -54,6 +54,8 @@ public class BigQueryFederationExpressionParserTest
     private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryFederationExpressionParserTest.class);
     private static final String COLUMN_QUOTE_CHAR = "\"";
     private static final String CONSTANT_QUOTE_CHAR = "'";
+    private static final String INPUT_ARGUMENT1 = "110";
+    private static final String INPUT_ARGUMENT2 = "120";
 
     BlockAllocator blockAllocator;
     ArrowType intType = new ArrowType.Int(32, true);
@@ -126,6 +128,78 @@ public class BigQueryFederationExpressionParserTest
         FunctionName negateFunction = StandardFunctions.NEGATE_FUNCTION_NAME.getFunctionName();
         String negateClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(negateFunction, intType, ImmutableList.of("110"));
         assertEquals(negateClause, "(-110)");
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_DivideFunction()
+    {
+        FunctionName divideFunction = StandardFunctions.DIVIDE_FUNCTION_NAME.getFunctionName();
+        String divClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(divideFunction, intType, ImmutableList.of("`col1`", INPUT_ARGUMENT1));
+        assertEquals("(`col1` / 110)", divClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_MulFunction()
+    {
+        FunctionName mulFunction = StandardFunctions.MULTIPLY_FUNCTION_NAME.getFunctionName();
+        String mulClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(mulFunction, intType, ImmutableList.of("`col1`", INPUT_ARGUMENT1));
+        assertEquals("(`col1` * 110)", mulClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_EqualFunction()
+    {
+        FunctionName equalFunction = StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME.getFunctionName();
+        String equalClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(equalFunction, intType, ImmutableList.of("`col1`", INPUT_ARGUMENT1));
+        assertEquals("(`col1` = 110)", equalClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_GreaterEqlFunction()
+    {
+        FunctionName grtEqlFunction = StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME.getFunctionName();
+        String grtEqlClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(grtEqlFunction, intType, ImmutableList.of("`col1`", INPUT_ARGUMENT1));
+        assertEquals("(`col1` >= 110)", grtEqlClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_LessEqlFunction()
+    {
+        FunctionName lesEqlFunction = StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME.getFunctionName();
+        String lesEqlClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(lesEqlFunction, intType, ImmutableList.of("`col1`", INPUT_ARGUMENT1));
+        assertEquals("(`col1` <= 110)", lesEqlClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_LikeFunction()
+    {
+        FunctionName likeFunction = StandardFunctions.LIKE_PATTERN_FUNCTION_NAME.getFunctionName();
+        String likeClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(likeFunction, intType, ImmutableList.of(INPUT_ARGUMENT1, INPUT_ARGUMENT2));
+        assertEquals("(110 LIKE 120)", likeClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_NotFunction()
+    {
+        FunctionName notFunction = StandardFunctions.NOT_FUNCTION_NAME.getFunctionName();
+        String notClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(notFunction, intType, ImmutableList.of(INPUT_ARGUMENT1));
+        assertEquals("( NOT 110)", notClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_IsDistinctFunction()
+    {
+        FunctionName isDistFunction = StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME.getFunctionName();
+        String isDistClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(isDistFunction, intType, ImmutableList.of(INPUT_ARGUMENT1, INPUT_ARGUMENT2));
+        assertEquals("(110 IS DISTINCT FROM 120)", isDistClause);
+    }
+
+    @Test
+    public void testCreateSqlForComplexExpressionContent_NullIfFunction()
+    {
+        FunctionName nullIfFunction = StandardFunctions.NULLIF_FUNCTION_NAME.getFunctionName();
+        String nullIfClause = bigQueryExpressionParser.mapFunctionToDataSourceSyntax(nullIfFunction, intType, ImmutableList.of(INPUT_ARGUMENT1, INPUT_ARGUMENT2));
+        assertEquals("(NULLIF(110, 120))", nullIfClause);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
@@ -38,10 +38,18 @@ import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
@@ -81,6 +89,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -89,12 +98,15 @@ import java.util.UUID;
 
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static com.amazonaws.athena.connectors.google.bigquery.BigQueryTestUtils.getBlockTestSchema;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -139,6 +151,8 @@ public class BigQueryRecordHandlerTest
     private MockedStatic<MessageSerializer> messageSer;
     MockedConstruction<VectorSchemaRoot> mockedDefaultVectorSchemaRoot;
     MockedConstruction<VectorLoader> mockedDefaultVectorLoader;
+    @Mock
+    private Job queryJob;
 
     public List<FieldVector> getFieldVectors()
     {
@@ -239,10 +253,7 @@ public class BigQueryRecordHandlerTest
     @After
     public void close()
     {
-        mockedDefaultVectorLoader.close();
-        mockedDefaultVectorSchemaRoot.close();
         mockedStatic.close();
-        messageSer.close();
         allocator.close();
     }
 
@@ -250,24 +261,7 @@ public class BigQueryRecordHandlerTest
     public void testReadWithConstraint()
             throws Exception
     {
-        try (ReadRecordsRequest request = new ReadRecordsRequest(
-                federatedIdentity,
-                BigQueryTestUtils.PROJECT_1_NAME,
-                "queryId",
-                new TableName("dataset1", "table1"),
-                getBlockTestSchema(),
-                Split.newBuilder(S3SpillLocation.newBuilder()
-                                .withBucket(bucket)
-                                .withPrefix(prefix)
-                                .withSplitId(UUID.randomUUID().toString())
-                                .withQueryId(UUID.randomUUID().toString())
-                                .withIsDirectory(true)
-                                .build(),
-                        keyFactory.create()).build(),
-                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
-                0,          //This is ignored when directly calling readWithConstraints.
-                0)) {
-
+        try (ReadRecordsRequest request = getReadRecordsRequest(Collections.emptyMap())) {
             // Mocking necessary dependencies
             ReadSession readSession = mock(ReadSession.class);
             ReadRowsResponse readRowsResponse = mock(ReadRowsResponse.class);
@@ -319,6 +313,106 @@ public class BigQueryRecordHandlerTest
 
             //Ensure that there was a spill so that we can read the spilled block.
             assertTrue(spillWriter.spilled());
+            mockedDefaultVectorLoader.close();
+            mockedDefaultVectorSchemaRoot.close();
+            messageSer.close();
         }
+    }
+
+    @Test
+    public void testReadWithConstraint_QueryPassThrough_Success() throws Exception
+    {
+        Map<String, String> passthroughArgs = getPassthroughArgs();
+        try (ReadRecordsRequest request = getReadRecordsRequest(passthroughArgs)) {
+            QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
+            when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+            when(bigQuery.create(any(JobInfo.class))).thenReturn(queryJob);
+            when(queryJob.isDone()).thenReturn(false).thenReturn(true);
+            TableResult result = setupMockTableResult();
+
+            when(queryJob.getQueryResults()).thenReturn(result);
+
+            //Execute the test
+            bigQueryRecordHandler.readWithConstraint(spillWriter, request, queryStatusChecker);
+
+            // Verify
+            verify(bigQuery).create(any(JobInfo.class));
+            verify(queryJob).getQueryResults();
+            verify(queryStatusChecker).isQueryRunning();
+        }
+    }
+
+    @Test
+    public void testReadWithConstraint_QueryPassThrough_JobExists() throws Exception
+    {
+        Map<String, String> passthroughArgs = getPassthroughArgs();
+        try (ReadRecordsRequest request = getReadRecordsRequest(passthroughArgs);
+             QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class)) {
+
+            //Job Already Exists Scenario
+            when(bigQuery.create(any(JobInfo.class))).thenThrow(new BigQueryException(409, "Job Already Exists"));
+
+            //Execute the test
+            BigQueryException exception = assertThrows(BigQueryException.class, () ->
+                    bigQueryRecordHandler.readWithConstraint(spillWriter, request, queryStatusChecker)
+            );
+
+            assertTrue(exception.getMessage().contains("Job Already Exists"));
+            assertEquals(409, exception.getCode());
+        }
+    }
+
+    private Map<String, String> getPassthroughArgs() {
+        return Map.of(
+                "schemaFunctionName", "SYSTEM.QUERY",
+                "QUERY", "SELECT * FROM test_table");
+    }
+
+    private ReadRecordsRequest getReadRecordsRequest(Map<String, String> passthroughArgs) {
+        return new ReadRecordsRequest(
+                federatedIdentity,
+                BigQueryTestUtils.PROJECT_1_NAME,
+                "queryId",
+                new TableName("dataset1", "table1"),
+                getBlockTestSchema(),
+                Split.newBuilder(S3SpillLocation.newBuilder()
+                                .withBucket(bucket)
+                                .withPrefix(prefix)
+                                .withSplitId(UUID.randomUUID().toString())
+                                .withQueryId(UUID.randomUUID().toString())
+                                .withIsDirectory(true)
+                                .build(),
+                        keyFactory.create()).build(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, passthroughArgs, null),
+                0,
+                0);
+    }
+
+    private TableResult setupMockTableResult() {
+        TableResult result = mock(TableResult.class, Mockito.RETURNS_DEEP_STUBS);
+        // added schema with bool,int,string,float columns
+        List<com.google.cloud.bigquery.Field> testSchemaFields = Arrays.asList(com.google.cloud.bigquery.Field.of(
+                        "bool1", LegacySQLTypeName.BOOLEAN),
+                com.google.cloud.bigquery.Field.of(
+                        "int1", LegacySQLTypeName.INTEGER),
+                com.google.cloud.bigquery.Field.of(
+                        "string1", LegacySQLTypeName.STRING),
+                com.google.cloud.bigquery.Field.of(
+                        "float1", LegacySQLTypeName.FLOAT));
+        com.google.cloud.bigquery.Schema tableSchema = com.google.cloud.bigquery.Schema.of(testSchemaFields);
+
+        List<FieldValue> bigQueryRowValue = Arrays.asList(FieldValue.of(FieldValue.Attribute.PRIMITIVE, "true"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "1"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "test"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "10.0"));
+        FieldValueList fieldValueList = FieldValueList.of(bigQueryRowValue,
+                FieldList.of(testSchemaFields));
+        List<FieldValueList> tableRows = List.of(fieldValueList);
+
+        when(result.getSchema()).thenReturn(tableSchema);
+        when(result.iterateAll()).thenReturn(tableRows);
+        when(result.getPageNoSchema()).thenReturn(new BigQueryPage<>(tableRows));
+
+        return result;
     }
 }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
@@ -19,16 +19,26 @@
  */
 package com.amazonaws.athena.connectors.google.bigquery;
 
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
+import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Ranges;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.common.collect.ImmutableList;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,10 +55,22 @@ import static org.junit.Assert.assertEquals;
 
 public class BigQuerySqlUtilsTest
 {
-    static final TableName tableName = new TableName("schema", "table");
+    private static final String SCHEMA_NAME = "schema";
+    private static final String TABLE_NAME = "table";
+    static final TableName tableName = new TableName(SCHEMA_NAME, TABLE_NAME);
+    private static final String TEST_DATE = "2023-01-01";
+    private static final String TEST_TIME = "10:30:00";
+    private static final String TEST_DATETIME = TEST_DATE + "T" + TEST_TIME;
+    private static final String TEST_DATETIME_MICROS = TEST_DATETIME + ".123";
+    private static final String TEST_DATETIME_PADDED = TEST_DATE + " " + TEST_TIME + ".000000";
+    private static final String INT_COL = "intCol";
+    private static final String VALUE_PREFIX = "value";
+    private static final double TEST_FLOAT = 123.456;
     static final ArrowType BOOLEAN_TYPE = ArrowType.Bool.INSTANCE;
     static final ArrowType INT_TYPE = new ArrowType.Int(32, false);
     static final ArrowType STRING_TYPE = new ArrowType.Utf8();
+    static final ArrowType FLOAT_TYPE = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+    static final ArrowType DATE_TYPE = new ArrowType.Date(DateUnit.DAY);
     private BlockAllocatorImpl allocator;
 
     @Before
@@ -98,17 +120,309 @@ public class BigQuerySqlUtilsTest
                 QueryParameterValue.string("a_low"), QueryParameterValue.string("z_high"),
                 QueryParameterValue.bool(true),
                 QueryParameterValue.int64(10), QueryParameterValue.int64(1000000));
+        String expectedSql = "SELECT `integerRange`,`isNullRange`,`isNotNullRange`,`stringRange`,`booleanRange`,`integerInRange` from `schema`.`table` " +
+                "WHERE ((integerRange IS NULL) OR (`integerRange` > ? AND `integerRange` < ?)) " +
+                "AND (isNullRange IS NULL) AND (isNotNullRange IS NOT NULL) " +
+                "AND ((`stringRange` >= ? AND `stringRange` < ?)) " +
+                "AND (`booleanRange` = ?) " +
+                "AND (`integerInRange` IN (?,?))";
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, makeSchema(constraintMap), expectedParameterValues, expectedSql);
+    }
 
-        try (Constraints constraints = new Constraints(constraintMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null)) {
-            List<QueryParameterValue> parameterValues = new ArrayList<>();
-            String sql = BigQuerySqlUtils.buildSql(tableName, makeSchema(constraintMap), constraints, parameterValues);
-            assertEquals(expectedParameterValues, parameterValues);
-            assertEquals("SELECT `integerRange`,`isNullRange`,`isNotNullRange`,`stringRange`,`booleanRange`,`integerInRange` from `schema`.`table` " +
-                    "WHERE ((integerRange IS NULL) OR (`integerRange` > ? AND `integerRange` < ?)) " +
-                    "AND (isNullRange IS NULL) AND (isNotNullRange IS NOT NULL) " +
-                    "AND ((`stringRange` >= ? AND `stringRange` < ?)) " +
-                    "AND (`booleanRange` = ?) " +
-                    "AND (`integerInRange` IN (?,?))", sql);
+    @Test
+    public void testSqlWithOrderByAndLimit()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        ValueSet rangeSet = SortedRangeSet.newBuilder(INT_TYPE, false)
+                .add(new Range(Marker.above(allocator, INT_TYPE, 0), Marker.below(allocator, INT_TYPE, 100)))
+                .build();
+        constraintMap.put(INT_COL, rangeSet);
+
+        List<OrderByField> orderByFields = ImmutableList.of(
+            new OrderByField(INT_COL, OrderByField.Direction.ASC_NULLS_FIRST),
+            new OrderByField("stringCol", OrderByField.Direction.DESC_NULLS_LAST)
+        );
+        List<QueryParameterValue> expectedParams = ImmutableList.of(
+                QueryParameterValue.int64(0),
+                QueryParameterValue.int64(100)
+        );
+        String expectedSql = "SELECT `intCol` from `schema`.`table` WHERE ((`intCol` > ? AND `intCol` < ?)) " +
+                "ORDER BY `intCol` ASC NULLS FIRST, `stringCol` DESC NULLS LAST limit 10";
+        Constraints constraints = getConstraints(constraintMap, orderByFields, 10);
+        executeAndVerify(constraints, makeSchema(constraintMap), expectedParams, expectedSql);
+    }
+
+    @Test
+    public void testSqlWithComplexDataTypes()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+
+        // Float test
+        ValueSet floatSet = SortedRangeSet.newBuilder(FLOAT_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, FLOAT_TYPE, TEST_FLOAT), 
+                             Marker.exactly(allocator, FLOAT_TYPE, TEST_FLOAT)))
+                .build();
+        constraintMap.put("floatCol", floatSet);
+
+        // Date test
+        // Calculate days since epoch for 2023-01-01
+        long daysFromEpoch = java.time.LocalDate.of(2023, 1, 1).toEpochDay();
+        ValueSet dateSet = SortedRangeSet.newBuilder(DATE_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, DATE_TYPE, daysFromEpoch), 
+                             Marker.exactly(allocator, DATE_TYPE, daysFromEpoch)))
+                .build();
+        constraintMap.put("dateCol", dateSet);
+        List<QueryParameterValue> expectedParams = ImmutableList.of(
+                QueryParameterValue.float64(123.456),
+                QueryParameterValue.date(TEST_DATE)
+        );
+        String expectedSql = "SELECT `floatCol`,`dateCol` from `schema`.`table` " +
+                "WHERE (`floatCol` = ?) AND (`dateCol` = ?)";
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, makeSchema(constraintMap), expectedParams, expectedSql);
+    }
+
+    @Test
+    public void testSqlWithNullAndEmptyChecks()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+
+        ValueSet nullSet = SortedRangeSet.newBuilder(STRING_TYPE, true).build();
+        constraintMap.put("nullCol", nullSet);
+
+        ValueSet nonNullSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.lowerUnbounded(allocator, STRING_TYPE), 
+                             Marker.upperUnbounded(allocator, STRING_TYPE)))
+                .build();
+        constraintMap.put("nonNullCol", nonNullSet);
+
+        ValueSet emptyStringSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, ""), 
+                             Marker.exactly(allocator, STRING_TYPE, "")))
+                .build();
+        constraintMap.put("emptyCol", emptyStringSet);
+        List<QueryParameterValue> expectedParams = ImmutableList.of(QueryParameterValue.string(""));
+        String expectedSql = "SELECT `nullCol`,`nonNullCol`,`emptyCol` from `schema`.`table` " +
+                "WHERE (nullCol IS NULL) AND (nonNullCol IS NOT NULL) AND (`emptyCol` = ?)";
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, makeSchema(constraintMap), expectedParams, expectedSql);
+    }
+
+    @Test
+    public void testSqlWithMultipleInValues()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        String valueOne = "1";
+        String valueTwo = "2";
+        String valueThree = "3";
+        // Multiple exact values using IN clause
+        ValueSet inSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, VALUE_PREFIX + valueOne),
+                             Marker.exactly(allocator, STRING_TYPE, VALUE_PREFIX + valueOne)))
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, VALUE_PREFIX + valueTwo),
+                             Marker.exactly(allocator, STRING_TYPE, VALUE_PREFIX + valueTwo)))
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, VALUE_PREFIX + valueThree),
+                             Marker.exactly(allocator, STRING_TYPE, VALUE_PREFIX + valueThree)))
+                .build();
+        constraintMap.put("multiValueCol", inSet);
+        String expectedSql = "SELECT `multiValueCol` from `schema`.`table` WHERE (`multiValueCol` IN (?,?,?))";
+        List<QueryParameterValue> expectedParams = ImmutableList.of(
+                QueryParameterValue.string(VALUE_PREFIX + valueOne),
+                QueryParameterValue.string(VALUE_PREFIX + valueTwo),
+                QueryParameterValue.string(VALUE_PREFIX + valueThree)
+        );
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, makeSchema(constraintMap), expectedParams, expectedSql);
+    }
+
+    @Test
+    public void testSqlWithEmptySchema()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        String expectedSql = "SELECT null from `schema`.`table`";
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, makeSchema(constraintMap), Collections.emptyList(), expectedSql);
+    }
+
+    @Test
+    public void testSqlWithoutConstraints()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        ValueSet rangeSet = SortedRangeSet.newBuilder(INT_TYPE, false)
+                .add(new Range(Marker.above(allocator, INT_TYPE, 0), Marker.below(allocator, INT_TYPE, 100)))
+                .build();
+        constraintMap.put(INT_COL, rangeSet);
+        String expectedSql = "SELECT `intCol` from `schema`.`table`";
+        Constraints constraints = getConstraints(Collections.emptyMap(), Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, makeSchema(constraintMap), Collections.emptyList(), expectedSql);
+    }
+
+    @Test
+    public void testSqlWithDateMicrosecondsHandling()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+
+        // Test date with timestamp string without microseconds (length == 19)
+        ValueSet dateNoMicrosSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, TEST_DATETIME),
+                        Marker.exactly(allocator, STRING_TYPE, TEST_DATETIME)))
+                .build();
+        String dateNoMicrosCol = "dateNoMicrosCol";
+        constraintMap.put(dateNoMicrosCol, dateNoMicrosSet);
+
+        // Test date with timestamp string with microseconds (length > 19)
+        ValueSet dateMicrosSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, TEST_DATETIME_MICROS),
+                        Marker.exactly(allocator, STRING_TYPE, TEST_DATETIME_MICROS)))
+                .build();
+        String dateMicrosCol = "dateMicrosCol";
+        constraintMap.put(dateMicrosCol, dateMicrosSet);
+
+        // Create schema that maps string values to DATE_TYPE to trigger the if block
+        List<Field> fields = new ArrayList<>();
+        fields.add(Field.nullable(dateNoMicrosCol, DATE_TYPE));  // Map string to DATE_TYPE
+        fields.add(Field.nullable(dateMicrosCol, DATE_TYPE));    // Map string to DATE_TYPE
+        Schema schema = new Schema(fields);
+        // For dateNoMicrosCol (length == 19), we expect .0 to be appended and padded to 6 digits
+        // For dateMicrosCol (length > 19), we expect the .123 to be padded to 6 digits
+        List<QueryParameterValue> expectedParams = ImmutableList.of(
+                QueryParameterValue.dateTime(TEST_DATETIME_PADDED),  // .0 appended and padded
+                QueryParameterValue.dateTime(TEST_DATE + " " + TEST_TIME + ".123000")   // .123 padded
+        );
+        String expectedSql = "SELECT `dateNoMicrosCol`,`dateMicrosCol` from `schema`.`table` " +
+                "WHERE (`dateNoMicrosCol` = ?) AND (`dateMicrosCol` = ?)";
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, schema, expectedParams, expectedSql);
+    }
+
+    @Test
+    public void testSqlWithDateRangePredicates()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        String dateValue = "2023-01-01T10:30:00";
+        // Test date with <= predicate using string format (contains "-")
+        ValueSet dateStringLteSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.lowerUnbounded(allocator, STRING_TYPE),
+                             Marker.exactly(allocator, STRING_TYPE, dateValue)))
+                .build();
+        String dateStringLteCol = "dateStringLteCol";
+        constraintMap.put(dateStringLteCol, dateStringLteSet);
+
+        // Test date with >= predicate using string format
+        ValueSet dateStringGteSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, STRING_TYPE, dateValue),
+                             Marker.upperUnbounded(allocator, STRING_TYPE)))
+                .build();
+        String dateStringGteCol = "dateStringGteCol";
+        constraintMap.put(dateStringGteCol, dateStringGteSet);
+
+        // Test date with <= predicate using epoch days
+        long epochDays = java.time.LocalDate.of(2023, 1, 1).toEpochDay();
+        ValueSet dateEpochLteSet = SortedRangeSet.newBuilder(DATE_TYPE, false)
+                .add(new Range(Marker.lowerUnbounded(allocator, DATE_TYPE),
+                             Marker.exactly(allocator, DATE_TYPE, epochDays)))
+                .build();
+        String dateEpochLteCol = "dateEpochLteCol";
+        constraintMap.put(dateEpochLteCol, dateEpochLteSet);
+
+        // Test date with >= predicate using epoch days
+        ValueSet dateEpochGteSet = SortedRangeSet.newBuilder(DATE_TYPE, false)
+                .add(new Range(Marker.exactly(allocator, DATE_TYPE, epochDays),
+                             Marker.upperUnbounded(allocator, DATE_TYPE)))
+                .build();
+        String dateEpochGteCol = "dateEpochGteCol";
+        constraintMap.put(dateEpochGteCol, dateEpochGteSet);
+
+        // Create schema that maps string values to DATE_TYPE to trigger the if block
+        List<Field> fields = new ArrayList<>();
+        fields.add(Field.nullable(dateStringLteCol, DATE_TYPE));    // Map string to DATE_TYPE
+        fields.add(Field.nullable(dateStringGteCol, DATE_TYPE));    // Map string to DATE_TYPE
+        fields.add(Field.nullable(dateEpochLteCol, DATE_TYPE));     // Keep as DATE_TYPE
+        fields.add(Field.nullable(dateEpochGteCol, DATE_TYPE));     // Keep as DATE_TYPE
+        Schema schema = new Schema(fields);
+        // For string dates, we expect datetime parameters with microseconds
+        // For epoch days, we expect date parameters
+        List<QueryParameterValue> expectedParams = ImmutableList.of(
+                QueryParameterValue.dateTime(TEST_DATETIME_PADDED),  // String LTE
+                QueryParameterValue.dateTime(TEST_DATETIME_PADDED),  // String GTE
+                QueryParameterValue.date(TEST_DATE),                 // Epoch LTE
+                QueryParameterValue.date(TEST_DATE)                  // Epoch GTE
+        );
+        String expectedSql = "SELECT `dateStringLteCol`,`dateStringGteCol`,`dateEpochLteCol`,`dateEpochGteCol` from `schema`.`table` " +
+                "WHERE ((`dateStringLteCol` <= ?)) AND ((`dateStringGteCol` >= ?)) AND " +
+                "((`dateEpochLteCol` <= ?)) AND ((`dateEpochGteCol` >= ?))";
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        executeAndVerify(constraints, schema, expectedParams, expectedSql);
+    }
+
+    /**
+     * Tests that BigQuerySqlUtils correctly validates range bounds when building SQL predicates.
+     * We need to mock Range and related objects because:
+     * 1. Real Range objects validate bounds at construction time, throwing exceptions before reaching our code
+     * 2. We want to test BigQuerySqlUtils's own validation logic for invalid bounds
+     * 3. The validation happens in multiple steps requiring a complete range hierarchy:
+     *    - SortedRangeSet.getSpan() is called to check for unbounded ranges
+     *    - Range.getLow()/getHigh() are called to get markers
+     *    - Marker.getBound() is called to validate bound types
+     */
+    @Test
+    public void testSqlWithInvalidBoundCombinations() {
+        // Mock the components of a Range to bypass Range's own validation
+        Marker lowMarker = mock(Marker.class);
+        Marker highMarker = mock(Marker.class);
+        Range range = mock(Range.class);
+
+        when(range.getLow()).thenReturn(lowMarker);
+        when(range.getHigh()).thenReturn(highMarker);
+        when(lowMarker.getBound()).thenReturn(Marker.Bound.BELOW);  // Invalid: low marker cannot be BELOW
+        when(highMarker.getBound()).thenReturn(Marker.Bound.EXACTLY);
+        when(lowMarker.getValue()).thenReturn(10);
+        when(highMarker.getValue()).thenReturn(20);
+        when(lowMarker.isLowerUnbounded()).thenReturn(false);
+        when(highMarker.isUpperUnbounded()).thenReturn(false);
+
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        SortedRangeSet rangeSet = mock(SortedRangeSet.class);
+        Ranges ranges = mock(Ranges.class);
+        when(ranges.getOrderedRanges()).thenReturn(ImmutableList.of(range));
+        when(rangeSet.getRanges()).thenReturn(ranges);
+        when(rangeSet.isNone()).thenReturn(false);
+        when(rangeSet.isNullAllowed()).thenReturn(false);
+        when(rangeSet.getType()).thenReturn(INT_TYPE);
+        when(rangeSet.getSpan()).thenReturn(range);
+        constraintMap.put("testColumn", rangeSet);
+
+        // Test that BigQuerySqlUtils throws IllegalArgumentException for low marker with BELOW bound
+        Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
+        List<QueryParameterValue> parameterValues = new ArrayList<>();
+        try {
+            BigQuerySqlUtils.buildSql(tableName, makeSchema(constraintMap), constraints, parameterValues);
+            fail("Expected IllegalArgumentException for low marker with BELOW bound");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Low marker should never use BELOW bound", e.getMessage());
         }
+
+        // Test high marker with ABOVE bound
+        when(lowMarker.getBound()).thenReturn(Marker.Bound.EXACTLY);
+        when(highMarker.getBound()).thenReturn(Marker.Bound.ABOVE);
+
+        // Test that BigQuerySqlUtils throws IllegalArgumentException for high marker with ABOVE bound
+        try {
+            BigQuerySqlUtils.buildSql(tableName, makeSchema(constraintMap), constraints, parameterValues);
+            fail("Expected IllegalArgumentException for high marker with ABOVE bound");
+        } catch (IllegalArgumentException e) {
+            assertEquals("High marker should never use ABOVE bound", e.getMessage());
+        }
+    }
+
+    private Constraints getConstraints(Map<String, ValueSet> constraintMap, List<OrderByField> orderByFields, long limit) {
+        return new Constraints(constraintMap, Collections.emptyList(), orderByFields, limit, Collections.emptyMap(), null);
+    }
+    private void executeAndVerify(Constraints constraints, Schema schema, List<QueryParameterValue> expectedParams, String expectedSql) {
+        List<QueryParameterValue> parameterValues = new ArrayList<>();
+        String sql = BigQuerySqlUtils.buildSql(tableName, schema, constraints, parameterValues);
+        assertEquals(expectedParams, parameterValues);
+        assertEquals(expectedSql, sql);
     }
 }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryTestUtils.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryTestUtils.java
@@ -149,6 +149,12 @@ public class BigQueryTestUtils
                 case Utf8:
                     builder.addStringField(field.getKey());
                     break;
+                case FloatingPoint:
+                    builder.addFloat8Field(field.getKey());
+                    break;
+                case Date:
+                    builder.addDateDayField(field.getKey());
+                    break;
                 default:
                     throw new UnsupportedOperationException("Type Not Implemented: " + typeId.name());
             }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
@@ -19,31 +19,83 @@
  */
 package com.amazonaws.athena.connectors.google.bigquery;
 
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
+import com.google.common.collect.ImmutableSet;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BigQueryUtilsTest
 {
-    private static final Logger logger = LoggerFactory.getLogger(BigQueryRecordHandler.class);
     @Mock
     BigQuery bigQuery;
     BigQueryPage<Dataset> datasets;
     BigQueryPage<Table> tables;
     String datasetName;
+    @Mock
+    private SecretsManagerClient secretsManagerClient;
+    @Mock
+    private ServiceAccountCredentials serviceAccountCredentials;
+    private MockedStatic<ServiceAccountCredentials> mockedServiceAccountCredentials;
+    private MockedStatic<SecretsManagerClient> mockedAWSSecretsManagerClientBuilder;
+    private Map<String, String> configOptions;
+    RootAllocator rootAllocator = new RootAllocator(Long.MAX_VALUE);
+    private static final String FIELD_NAME = "test";
+    private static final String DATASET_NAME = "dataset1";
+    private static final String CREDS_SM_NAME = "test-secret-id";
 
     @Before
     public void init()
@@ -51,21 +103,339 @@ public class BigQueryUtilsTest
         System.setProperty("aws.region", "us-east-1");
 
         //Mock the BigQuery Client to return Datasets, and Table Schema information.
-        datasets = new BigQueryPage<Dataset>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, 2));
+        datasets = new BigQueryPage<>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, 2));
         when(bigQuery.listDatasets(nullable(String.class))).thenReturn(datasets);
         //Get the first dataset name.
         datasetName = datasets.iterateAll().iterator().next().getDatasetId().getDataset();
-        tables = new BigQueryPage<Table>(BigQueryTestUtils.getTableList(BigQueryTestUtils.PROJECT_1_NAME, "dataset1", 2));
+        tables = new BigQueryPage<>(BigQueryTestUtils.getTableList(BigQueryTestUtils.PROJECT_1_NAME, DATASET_NAME, 2));
         when(bigQuery.listTables(nullable(DatasetId.class))).thenReturn(tables);
+        configOptions = new HashMap<>();
+        mockedServiceAccountCredentials = mockStatic(ServiceAccountCredentials.class);
+        mockedAWSSecretsManagerClientBuilder = mockStatic(SecretsManagerClient.class);
+    }
+
+    @After
+    public void tearDown()
+    {
+        mockedServiceAccountCredentials.close();
+        mockedAWSSecretsManagerClientBuilder.close();
+        rootAllocator.close();
+    }
+
+    @Test
+    public void testFixCaseForDatasetName()
+    {
+        String result = BigQueryUtils.fixCaseForDatasetName(BigQueryTestUtils.PROJECT_1_NAME, DATASET_NAME, bigQuery);
+        assertEquals(DATASET_NAME, result);
+    }
+
+    @Test
+    public void testFixCaseForTableName()
+    {
+        final String expectedTableName = "table1";
+        String result = BigQueryUtils.fixCaseForTableName(
+                BigQueryTestUtils.PROJECT_1_NAME, datasetName, expectedTableName, bigQuery);
+        assertEquals(expectedTableName, result);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void bigQueryUtils()
+    public void testFixCaseForTableNameNotFound()
     {
-        String newDatasetName = BigQueryUtils.fixCaseForDatasetName(BigQueryTestUtils.PROJECT_1_NAME, "testDataset", bigQuery);
-        assertNull(newDatasetName);
+        BigQueryUtils.fixCaseForTableName(
+                BigQueryTestUtils.PROJECT_1_NAME, datasetName, "nonexistent", bigQuery);
+    }
 
-        String tableName = BigQueryUtils.fixCaseForTableName(BigQueryTestUtils.PROJECT_1_NAME, datasetName, "test", bigQuery);
-        assertNull(tableName);
+    @Test
+    public void testGetEnvBigQueryCredsSmId_Success() {
+
+        configOptions.put(BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID, CREDS_SM_NAME);
+        String actualSmId = BigQueryUtils.getEnvBigQueryCredsSmId(configOptions);
+
+        assertEquals(CREDS_SM_NAME, actualSmId);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetEnvBigQueryCredsSmId_EmptyValue_ThrowsException() {
+        configOptions.put(BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID, "");
+        BigQueryUtils.getEnvBigQueryCredsSmId(configOptions);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetEnvBigQueryCredsSmId_MissingValue_ThrowsException() {
+        BigQueryUtils.getEnvBigQueryCredsSmId(configOptions);
+    }
+
+    @Test
+    public void testGetCredentialsFromSecretsManager() throws IOException {
+        configOptions.put(BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID, CREDS_SM_NAME);
+        String secretJson = "{ \"type\": \"service_account\", \"project_id\": \"test-project\" }";
+        GetSecretValueResponse secretResponse = GetSecretValueResponse.builder()
+                .secretString(secretJson)
+                .build();
+
+        when(SecretsManagerClient.create()).thenReturn(secretsManagerClient);
+        when(secretsManagerClient.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(secretResponse);
+        when(ServiceAccountCredentials.fromStream(any())).thenReturn(serviceAccountCredentials);
+        when(serviceAccountCredentials.createScoped((Collection<String>) any()))
+                .thenReturn(serviceAccountCredentials);
+
+        Credentials result = BigQueryUtils.getCredentialsFromSecretsManager(configOptions);
+
+        assertNotNull(result);
+        verify(secretsManagerClient).getSecretValue(any(GetSecretValueRequest.class));
+        verify(serviceAccountCredentials).createScoped(eq(ImmutableSet.of(
+                "https://www.googleapis.com/auth/bigquery",
+                "https://www.googleapis.com/auth/drive")));
+    }
+
+    @Test
+    public void testTranslateToArrowType()
+    {
+        assertEquals(new ArrowType.Bool(), BigQueryUtils.translateToArrowType(LegacySQLTypeName.BOOLEAN));
+        assertEquals(new ArrowType.Int(64, true), BigQueryUtils.translateToArrowType(LegacySQLTypeName.INTEGER));
+        assertEquals(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
+                BigQueryUtils.translateToArrowType(LegacySQLTypeName.FLOAT));
+        assertEquals(new ArrowType.Decimal(38, 9, 128), BigQueryUtils.translateToArrowType(LegacySQLTypeName.NUMERIC));
+        assertEquals(new ArrowType.Binary(), BigQueryUtils.translateToArrowType(LegacySQLTypeName.BYTES));
+        assertEquals(new ArrowType.Struct(), BigQueryUtils.translateToArrowType(LegacySQLTypeName.RECORD));
+        assertEquals(new ArrowType.Date(DateUnit.DAY), BigQueryUtils.translateToArrowType(LegacySQLTypeName.DATE));
+        assertEquals(new ArrowType.Date(DateUnit.MILLISECOND),
+                BigQueryUtils.translateToArrowType(LegacySQLTypeName.DATETIME));
+        assertEquals(new ArrowType.Utf8(), BigQueryUtils.translateToArrowType(LegacySQLTypeName.STRING));
+    }
+
+    @Test
+    public void testGetChildFieldList()
+    {
+        Field simpleField = Field.of(FIELD_NAME, LegacySQLTypeName.STRING);
+        List<org.apache.arrow.vector.types.pojo.Field> result = BigQueryUtils.getChildFieldList(simpleField);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(FIELD_NAME, result.get(0).getName());
+        assertEquals(new ArrowType.Utf8(), result.get(0).getType());
+    }
+
+    @Test
+    public void testGetChildFieldListWithNestedStruct() {
+        List<Field> nestedFields = new ArrayList<>();
+        nestedFields.add(Field.of("nested1", LegacySQLTypeName.STRING));
+        nestedFields.add(Field.of("nested2", LegacySQLTypeName.INTEGER));
+        String expectedNestedField = "nested";
+        Field nestedStruct = Field.of(expectedNestedField, LegacySQLTypeName.RECORD, nestedFields.toArray(new Field[0]));
+        List<Field> fields = new ArrayList<>();
+        fields.add(Field.of(FIELD_NAME, LegacySQLTypeName.STRING));
+        fields.add(nestedStruct);
+
+        Field structField = Field.of("struct", LegacySQLTypeName.RECORD, fields.toArray(new Field[0]));
+
+        List<org.apache.arrow.vector.types.pojo.Field> result = BigQueryUtils.getChildFieldList(structField);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        // Check the nested struct field
+        org.apache.arrow.vector.types.pojo.Field nestedField = result.get(1);
+        assertEquals(expectedNestedField, nestedField.getName());
+        assertInstanceOf(ArrowType.Struct.class, nestedField.getType());
+        assertEquals(2, nestedField.getChildren().size());
+    }
+
+    @Test
+    public void testCoerceWithTimeVector() {
+        try (TimeMilliVector time = new TimeMilliVector("time", rootAllocator)) {
+            // Test coercing a Long value
+            Long timeInMillis = 3600000L; // 1 hour in milliseconds
+            Object result = BigQueryUtils.coerce(time, timeInMillis);
+            assertNotNull(result);
+            assertInstanceOf(String.class, result);
+            assertEquals("01:00", result);
+
+            // Test coercing a non-Long value
+            String timeString = "01:00";
+            result = BigQueryUtils.coerce(time, timeString);
+            assertNotNull(result);
+            assertInstanceOf(String.class, result);
+            assertEquals(timeString, result);
+        }
+    }
+
+    @Test
+    public void testCoerceWithTimestampVector() {
+        org.apache.arrow.vector.types.pojo.Field timestampField = new org.apache.arrow.vector.types.pojo.Field(
+                "timestamp",
+                new FieldType(true, new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"), null),
+                null
+        );
+        try (TimeStampMilliTZVector timestampVector = new TimeStampMilliTZVector(timestampField, rootAllocator)) {
+            // Test coercing a Long value (epoch milliseconds)
+            Long timestampInMillis = 1609459200000L; // 2021-01-01 00:00:00 UTC
+            Object result = BigQueryUtils.coerce(timestampVector, timestampInMillis);
+            assertNotNull(result);
+            assertInstanceOf(String.class, result);
+            assertEquals("2021-01-01T00:00", result.toString());
+
+            // Test coercing a non-Long value
+            String timestampString = "2021-01-01T00:00:00";
+            result = BigQueryUtils.coerce(timestampVector, timestampString);
+            assertNotNull(result);
+            assertEquals(timestampString, result);
+        }
+    }
+
+    @Test
+    public void testCoerceWithOtherVectorTypes_ReturnsSameAsInput() {
+        try (IntVector intVector = new IntVector("int", rootAllocator)) {
+            Integer expectedValue = 42;
+            Object result = BigQueryUtils.coerce(intVector, expectedValue);
+            assertEquals(expectedValue, result);
+        }
+    }
+
+    @Test
+    public void testGetObjectFromFieldValueWithDate() throws ParseException {
+        FieldValue dateValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "2023-01-01");
+        org.apache.arrow.vector.types.pojo.Field dateField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Date(DateUnit.DAY));
+
+        Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, dateValue, dateField, false);
+        assertNotNull(result);
+        assertInstanceOf(Long.class, result);
+        assertEquals(19358L, result);
+    }
+
+    @Test
+    public void testGetObjectFromFieldValueWithDateTime() throws ParseException {
+        FieldValue dateTimeValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "2023-01-01T12:00:00");
+        org.apache.arrow.vector.types.pojo.Field dateTimeField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Date(DateUnit.MILLISECOND));
+
+        Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, dateTimeValue, dateTimeField, false);
+        assertNotNull(result);
+        assertInstanceOf(Date.class, result);
+
+        dateTimeValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "2023-01-01T12:00:00.000000");
+        dateTimeField = org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Date(DateUnit.MILLISECOND));
+
+        result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, dateTimeValue, dateTimeField, false);
+        assertNotNull(result);
+        assertInstanceOf(LocalDateTime.class, result);
+        assertEquals(LocalDateTime.of(2023, 1, 1, 12, 0, 0), result);
+
+    }
+
+    @Test
+    public void testGetObjectFromFieldValueWithTimestamp() throws ParseException {
+        FieldValue timestampValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "12345");
+        org.apache.arrow.vector.types.pojo.Field timestampField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, null));
+
+        Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, timestampValue, timestampField, true);
+        assertNotNull(result);
+        assertInstanceOf(Long.class, result);
+        assertEquals(12345000L, result);
+    }
+
+    @Test
+    public void testGetObjectFromFieldValueWithDecimal() throws ParseException {
+        FieldValue decimalValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "123.45");
+        org.apache.arrow.vector.types.pojo.Field decimalField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Decimal(38, 9, 128));
+
+            Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, decimalValue, decimalField, false);
+            assertNotNull(result);
+            assertInstanceOf(BigDecimal.class, result);
+            assertEquals(new BigDecimal("123.45"), result);
+    }
+
+    @Test
+    public void testGetObjectFromFieldValueVarcharWithTimestamp() throws ParseException {
+        String timestampMillis = "1748604000000"; // Represents 2025-05-30T12:00:00Z
+        FieldValue varcharTimestampValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, timestampMillis);
+        org.apache.arrow.vector.types.pojo.Field varcharTimestampField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Utf8());
+        Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, varcharTimestampValue, varcharTimestampField, false);
+        assertNotNull(result);
+        assertInstanceOf(String.class, result);
+        assertEquals(timestampMillis, result);
+
+        result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, varcharTimestampValue, varcharTimestampField, true);
+        assertNotNull(result);
+        assertInstanceOf(Instant.class, result);
+    }
+
+    @Test
+    public void testGetObjectFromFieldValueWithNull() throws ParseException {
+        FieldValue nullValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, null);
+        org.apache.arrow.vector.types.pojo.Field field =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Utf8());
+        Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, nullValue, field, false);
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetComplexObjectFromFieldValueWithStruct() throws ParseException {
+        List<com.google.cloud.bigquery.Field> testSchemaFields = List.of(
+                Field.of(FIELD_NAME, LegacySQLTypeName.STRING));
+        List<FieldValue> bigQueryRowValue = List.of(FieldValue.of(FieldValue.Attribute.PRIMITIVE, "test"));
+        FieldValueList fieldValueList = FieldValueList.of(bigQueryRowValue,
+                FieldList.of(testSchemaFields));
+        FieldValue structValue = FieldValue.of(FieldValue.Attribute.RECORD, fieldValueList);
+        org.apache.arrow.vector.types.pojo.Field structField =
+                org.apache.arrow.vector.types.pojo.Field.nullable("struct", new ArrowType.Struct());
+
+        org.apache.arrow.vector.types.pojo.Field childField =
+                org.apache.arrow.vector.types.pojo.Field.nullable("element", new ArrowType.Utf8());
+        List<org.apache.arrow.vector.types.pojo.Field> children = new ArrayList<>();
+        children.add(childField);
+        structField = new org.apache.arrow.vector.types.pojo.Field(FIELD_NAME, structField.getFieldType(), children);
+        Object result = BigQueryUtils.getComplexObjectFromFieldValue(structField, structValue, false);
+        assertInstanceOf(Map.class, result);
+        Map<Object, Object> structResult = (Map<Object, Object>) result;
+        assertEquals(1, structResult.size());
+        assertEquals(FIELD_NAME, structResult.get("element"));
+    }
+
+    @Test
+    public void testGetComplexObjectFromFieldValueWithList() throws ParseException {
+        String expectedValue1 = "test1";
+        String expectedValue2 = "test2";
+        List<FieldValue> repeatedValues = new ArrayList<>();
+        repeatedValues.add(FieldValue.of(FieldValue.Attribute.PRIMITIVE, expectedValue1));
+        repeatedValues.add(FieldValue.of(FieldValue.Attribute.PRIMITIVE, expectedValue2));
+
+        FieldValue listValue = FieldValue.of(FieldValue.Attribute.REPEATED, repeatedValues);
+        org.apache.arrow.vector.types.pojo.Field listField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.List());
+        org.apache.arrow.vector.types.pojo.Field childField =
+                org.apache.arrow.vector.types.pojo.Field.nullable("element", new ArrowType.Utf8());
+        List<org.apache.arrow.vector.types.pojo.Field> children = new ArrayList<>();
+        children.add(childField);
+        listField = new org.apache.arrow.vector.types.pojo.Field(FIELD_NAME, listField.getFieldType(), children);
+        Object result = BigQueryUtils.getComplexObjectFromFieldValue(listField, listValue, false);
+        assertInstanceOf(List.class, result);
+        List<?> listResult = (List<?>) result;
+        assertEquals(2, listResult.size());
+        assertEquals(expectedValue1, listResult.get(0));
+        assertEquals(expectedValue2, listResult.get(1));
+    }
+
+    @Test(expected = ParseException.class)
+    public void testGetObjectFromFieldValueInvalidDate() throws ParseException {
+        FieldValue invalidDateValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "invalid-date");
+        org.apache.arrow.vector.types.pojo.Field dateField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, new ArrowType.Date(DateUnit.DAY));
+
+        BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, invalidDateValue, dateField, false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetObjectFromFieldValueUnknownType() throws ParseException {
+        FieldValue testValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, FIELD_NAME);
+        // Create a custom ArrowType that's not handled
+        ArrowType customType = new ArrowType.Null();
+        org.apache.arrow.vector.types.pojo.Field customField =
+                org.apache.arrow.vector.types.pojo.Field.nullable(FIELD_NAME, customType);
+
+        BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, testValue, customField, false);
     }
 }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/qpt/BigQueryQueryPassthroughTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/qpt/BigQueryQueryPassthroughTest.java
@@ -1,0 +1,48 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery.qpt;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class BigQueryQueryPassthroughTest {
+
+    private final BigQueryQueryPassthrough bigQueryQueryPassthrough = new BigQueryQueryPassthrough();
+
+    @Test
+    public void testGetFunctionSchema() {
+        assertEquals("system", bigQueryQueryPassthrough.getFunctionSchema());
+    }
+
+    @Test
+    public void testGetFunctionName() {
+        assertEquals("query", bigQueryQueryPassthrough.getFunctionName());
+    }
+
+    @Test
+    public void testGetFunctionArguments() {
+        assertEquals(List.of("QUERY"), bigQueryQueryPassthrough.getFunctionArguments());
+    }
+
+}


### PR DESCRIPTION
Add unit tests bigquery internal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests across BigQuery components: environment/property mapping, exception filtering for rate limits, expression parsing, metadata capabilities and query passthrough, record handler passthrough flows (including job-exists scenarios), SQL generation (ordering, complex types, null/empty, multi-IN, microseconds, date ranges).
  * Expanded utilities tests for credentials (env/Secrets Manager), dataset/table casing, Arrow type mappings, nested field extraction, value coercion, complex struct/list handling, and query-passthrough function metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->